### PR TITLE
New feature: enable setting lock dir permissions

### DIFF
--- a/NamedAtomicLock/__init__.py
+++ b/NamedAtomicLock/__init__.py
@@ -18,9 +18,9 @@ import time
 
 __all__ = ('NamedAtomicLock',)
 
-__version__ = '1.1.3'
+__version__ = '1.1.4'
 
-__version_tuple__ = (1, 1, 3)
+__version_tuple__ = (1, 1, 4)
 
 DEFAULT_POLL_TIME = .1
 
@@ -31,7 +31,7 @@ except:
 
 class NamedAtomicLock(object):
 
-    def __init__(self, name, lockDir=None, maxLockAge=None):
+    def __init__(self, name, lockDir=None, maxLockAge=None, mode=0o770):
         '''
             NamedAtomicLock - Create a NamedAtomicLock.
                 This uses a named directory, which is defined by POSIX as an atomic operation.
@@ -44,9 +44,13 @@ class NamedAtomicLock(object):
                 You should likely define this as a reasonable number, maybe 4x as long as you think the operation will take, so that the lock doesn't get
                 held by a dead process.
 
+            @param mode <integer> - The permissions mode value set for the created lock directory by the acquire function. It is a security best practice 
+                to not create world writable objects. The default value of 0o770 is backwards compatibility.
+
         '''
         self.name = name
         self.maxLockAge = maxLockAge
+        self.mode = mode
 
         if os.sep in name:
             raise ValueError('Name cannot contain "%s"' %(os.sep,))
@@ -106,7 +110,7 @@ class NamedAtomicLock(object):
         success = False
         while keepGoing():
             try:
-                os.mkdir(self.lockPath) 
+                os.mkdir(self.lockPath, self.mode) 
                 success = True
                 break
             except:


### PR DESCRIPTION
The directory that is created by the acquire function (i.e. os.mkdir command) uses the default setting of mode=0o777 (i.e. world writable) with no way to change it. It is a security best practice to not create world writable objects, and vulnerability scanners are known to check for world writable objects. A mode parameter with a default value of 0o777 for backwards compatibility was added to the class constructor, and the mode parameter was added to the os.mkdir command to allow the mode value to be customized.